### PR TITLE
Relax psr/log constraint to support Monolog 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "php": "^5.6 || ^7.0",
-        "psr/log": "^1.0"
+        "psr/log": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "behat/behat": "^2.5.5",


### PR DESCRIPTION
- Updated composer.json to require "psr/log": "^1.0 || ^2.0 || ^3.0"
- This change allows projects depending on this library to upgrade to Monolog 3 (which requires psr/log ^2.0 || ^3.0), while remaining backward compatible with existing installs on psr/log ^1.0.
- No functional changes, only dependency compatibility.